### PR TITLE
Support multiple emails & names for single contributor

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
           OS: linux
           ARCH: amd64
         run: |
+          apt-get update
+          apt-get install ca-certificates
+
           curl -O -L -C - https://github.com/editorconfig-checker/editorconfig-checker/releases/download/$VERSION/ec-$OS-$ARCH.tar.gz
           tar xzf ec-$OS-$ARCH.tar.gz
           ./bin/ec-$OS-$ARCH

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,18 +11,15 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Verify formatting
-        env:
-          VERSION: 2.7.0
-          OS: linux
-          ARCH: amd64
-        run: |
-          sudo apt-get update
-          sudo apt-get install ca-certificates
-
-          curl -O -L -C - https://github.com/editorconfig-checker/editorconfig-checker/releases/download/$VERSION/ec-$OS-$ARCH.tar.gz
-          tar xzf ec-$OS-$ARCH.tar.gz
-          ./bin/ec-$OS-$ARCH
+      # - name: Verify formatting
+      #   env:
+      #     VERSION: 2.7.0
+      #     OS: linux
+      #     ARCH: amd64
+      #   run: |
+      #     curl -O -L -C - https://github.com/editorconfig-checker/editorconfig-checker/releases/download/$VERSION/ec-$OS-$ARCH.tar.gz
+      #     tar xzf ec-$OS-$ARCH.tar.gz
+      #     ./bin/ec-$OS-$ARCH
 
       - name: Install nix
         uses: cachix/install-nix-action@v18

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.0
 
       - name: Verify formatting
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,15 +11,15 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      # - name: Verify formatting
-      #   env:
-      #     VERSION: 2.7.0
-      #     OS: linux
-      #     ARCH: amd64
-      #   run: |
-      #     curl -O -L -C - https://github.com/editorconfig-checker/editorconfig-checker/releases/download/$VERSION/ec-$OS-$ARCH.tar.gz
-      #     tar xzf ec-$OS-$ARCH.tar.gz
-      #     ./bin/ec-$OS-$ARCH
+      - name: Verify formatting
+        env:
+          VERSION: 2.7.0
+          OS: linux
+          ARCH: amd64
+        run: |
+          curl -O -L -C - https://github.com/editorconfig-checker/editorconfig-checker/releases/download/$VERSION/ec-$OS-$ARCH.tar.gz
+          tar xzf ec-$OS-$ARCH.tar.gz
+          ./bin/ec-$OS-$ARCH
 
       - name: Install nix
         uses: cachix/install-nix-action@v18

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,8 +17,8 @@ jobs:
           OS: linux
           ARCH: amd64
         run: |
-          apt-get update
-          apt-get install ca-certificates
+          sudo apt-get update
+          sudo apt-get install ca-certificates
 
           curl -O -L -C - https://github.com/editorconfig-checker/editorconfig-checker/releases/download/$VERSION/ec-$OS-$ARCH.tar.gz
           tar xzf ec-$OS-$ARCH.tar.gz

--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ name = "Tester"
 email = "tester@ictunion.cz"
 
 [very_public_person]
-name = "ME"
-email = "you-all-know@me.com"
+name = [ "ME", "My Other Name" ]
+email = [ "you-all-know@me.com", "other-email@somewhere.here" ]
 ```
 
 Committers listed in this file will be assigned as authors of their commits even
 in anonymized repository.
+
+Both values can be either string or list of strings for cases where single person
+is using multiple git configurations.
 
 ## Using The Project
 

--- a/git-anonymize.py
+++ b/git-anonymize.py
@@ -30,6 +30,17 @@ def build_parser():
     parser.add_argument("-e", "--email", default="anyone@world.org", help="email to use instead in commits")
     return parser
 
+def add_to_set(the_set, value):
+    # Single value is just added
+    if isinstance(value, str):
+        the_set.add(str.encode(value))
+    # If this is not string, lets assume it's list
+    else:
+        for string in value:
+            # We simply recurse
+            # this means we also technically support nested strings
+            add_to_set(the_set, string)
+
 def read_config(path):
     conf = {};
 
@@ -44,8 +55,8 @@ def read_config(path):
 
     for key in conf:
         value = conf[key];
-        allowed_emails.add(str.encode(value["email"]))
-        allowed_names.add(str.encode(value["name"]))
+        add_to_set(allowed_emails, value['email'])
+        add_to_set(allowed_names, value['name'])
 
     return {
         "allowed_emails": allowed_emails,

--- a/test/custom_config.toml
+++ b/test/custom_config.toml
@@ -1,3 +1,3 @@
 [tester]
-name = "Tester"
-email = "tester@ictunion.cz"
+name = [ "Tester", "PublicTester" ]
+email = [ "tester@ictunion.cz", "very-public@me.com" ]

--- a/test/custom_config.toml
+++ b/test/custom_config.toml
@@ -1,3 +1,3 @@
 [tester]
-name = [ "Tester", "PublicTester" ]
+name = "Tester"
 email = [ "tester@ictunion.cz", "very-public@me.com" ]

--- a/test/golden.sh
+++ b/test/golden.sh
@@ -23,11 +23,15 @@ git config commit.gpgsign false
 git config user.name "Tester"
 git config user.email "tester@ictunion.cz"
 
-# Create commits
+# create commits
 git commit --allow-empty -m "initial commit"
-echo "secret" > $SECRET_FILE
-git add .
-git commit -m "second commit"
+
+# keep committer but set alternative name and email
+git config user.name "PublicTester"
+git config user.email "very-public@me.com"
+
+# commit again
+git commit --allow-empty -m "second commit"
 
 # change committer
 git config user.name "Tester2"
@@ -35,6 +39,9 @@ git config user.email "tester2@ictunion.cz"
 
 # create commits as 2nd commiter
 git commit --allow-empty -m "fixing the mess"
+
+git config user.name "Tester2"
+git config user.email "tester2@ictunion.cz"
 
 echo ""
 echo "Running assertions:"

--- a/test/golden.sh
+++ b/test/golden.sh
@@ -27,7 +27,6 @@ git config user.email "tester@ictunion.cz"
 git commit --allow-empty -m "initial commit"
 
 # keep committer but set alternative name and email
-git config user.name "PublicTester"
 git config user.email "very-public@me.com"
 
 # commit again
@@ -39,9 +38,6 @@ git config user.email "tester2@ictunion.cz"
 
 # create commits as 2nd commiter
 git commit --allow-empty -m "fixing the mess"
-
-git config user.name "Tester2"
-git config user.email "tester2@ictunion.cz"
 
 echo ""
 echo "Running assertions:"
@@ -81,5 +77,17 @@ fi
 git log --pretty='%ce' | grep 'tester@ictunion.cz'
 if [ "$?" -ne 0 ]; then
     echo "Failed to allow tester email"
+    exit 4
+fi
+
+git log --pretty='%ce' | grep 'tester@ictunion.cz'
+if [ "$?" -ne 0 ]; then
+    echo "Failed to allow tester email"
+    exit 4
+fi
+
+git log --pretty='%ce' | grep 'very-public@me.com'
+if [ "$?" -ne 0 ]; then
+    echo "Failed to allow tester'sa 2nd email"
     exit 4
 fi


### PR DESCRIPTION
Implement support for multiple emails and names for single committer.

This is mainly motivated by the fact that on GitHub (web) a lot of users
commit with different user name and/or email as they use to commit from their computers.
This also allows people who have different git configs across their machines
to configure all machines in single entry to toml file.