### PR TITLE
Anonymize github mentions in commit messages

### DIFF
--- a/git-anonymize.py
+++ b/git-anonymize.py
@@ -3,6 +3,7 @@
 import git_filter_repo
 import tomli
 import argparse
+import re
 from argparse import RawTextHelpFormatter
 import sys
 import os
@@ -101,7 +102,8 @@ def rewrite_history(args, allowed_emails, allowed_names):
     # If this would be implemented definitely in future definitely don't forget
     # to add test in test/golden.sh!
     def message_callback(message):
-        message_str = message.decode()
+        # Strip github user mentions
+        message_str = re.sub(r'\B@((?!.*(-){2,}.*)[a-z0-9][a-z0-9-]{0,38}[a-z0-9])', '[anonymized]', message.decode())
         out = ""
         for line in message_str.split('\n'):
             # GitHub or Git sometimes adds Co-authored-by or Signed-off-by

--- a/test/golden.sh
+++ b/test/golden.sh
@@ -24,7 +24,7 @@ git config user.name "Tester"
 git config user.email "tester@ictunion.cz"
 
 # create commits
-git commit --allow-empty -m "initial commit"
+git commit --allow-empty --signoff -m "initial commit"
 
 # keep committer but set alternative name and email
 git config user.email "very-public@me.com"
@@ -40,7 +40,7 @@ git config user.name "Tester2"
 git config user.email "tester2@ictunion.cz"
 
 # create commits as 2nd commiter
-git commit --allow-empty -m "fixing the mess"
+git commit --allow-empty -m "fixing the mess ping @user!"
 
 echo ""
 echo "Running assertions:"


### PR DESCRIPTION
Anonymize git tags like `@userhandle` from commit messages.